### PR TITLE
Add .nvmrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ coverage/
 # Ignore IntelliJ IDEA project files
 .idea/
 
+# Ignore configuration for nvm (node version manager)
+.nvmrc
+
 # Ignore TSLint cache files
 tslint.cache
 


### PR DESCRIPTION
Updated .gitignore to exclude the .nvmrc file, preventing local Node.js version configuration from being tracked in version control.