### PR TITLE
Remove update by unique property methods and tests

### DIFF
--- a/src/data-manager/__tests__/data-manager.unit.test.ts
+++ b/src/data-manager/__tests__/data-manager.unit.test.ts
@@ -5,7 +5,7 @@ import sinon from "sinon";
 
 // Use jest for assertions
 
-describe("DataManager.updateItemInCollectionByUniquePropertyValue", () => {
+describe("DataManager", () => {
   let dataManager: DataManager;
   let dbStub: sinon.SinonStub;
   let checkInitStub: sinon.SinonStub;
@@ -13,10 +13,6 @@ describe("DataManager.updateItemInCollectionByUniquePropertyValue", () => {
 
   beforeEach(() => {
     dataManager = DataManager.getInstance();
-    dbStub = sinon.stub(
-      MongoDBManager,
-      "updateItemInCollectionByUniqueProperty"
-    );
     checkInitStub = sinon
       .stub(dataManager, "checkInitialization")
       .callsFake(() => {});
@@ -30,65 +26,7 @@ describe("DataManager.updateItemInCollectionByUniquePropertyValue", () => {
     DataManager.instance = null;
   });
 
-  it("should update item and emit userUpdated for USERS collection", async () => {
-    const updated = { name: "John" };
-    dbStub.resolves(updated);
-    const result =
-      await dataManager.updateItemInCollectionByUniquePropertyValue(
-        "USERS",
-        "email",
-        "john@example.com",
-        { name: "John" }
-      );
-    expect(result).toBe(updated);
-    expect(
-      emitSpy.calledWith("userUpdated", {
-        email: "john@example.com",
-        name: "John",
-      })
-    ).toBe(true);
-  });
-
-  it("should update item and not emit userUpdated for non-USERS collection", async () => {
-    const updated = { foo: "bar" };
-    dbStub.resolves(updated);
-    const result =
-      await dataManager.updateItemInCollectionByUniquePropertyValue(
-        "OTHER",
-        "id",
-        "123",
-        { foo: "bar" }
-      );
-    expect(result).toBe(updated);
-    expect(emitSpy.calledWith("userUpdated")).toBe(false);
-  });
-
-  it("should handle error and call handleDbError", async () => {
-    const error = new Error("fail");
-    dbStub.rejects(error);
-    const handleDbErrorStub = sinon
-      .stub(require("../data-manager.helpers"), "handleDbError")
-      .returns(null);
-    const result =
-      await dataManager.updateItemInCollectionByUniquePropertyValue(
-        "USERS",
-        "email",
-        "fail@example.com",
-        { name: "Fail" }
-      );
-    expect(handleDbErrorStub.called).toBe(true);
-    expect(result).toBeNull();
-    handleDbErrorStub.restore();
-  });
-  it("should call checkInitialization before updating", async () => {
-    const updated = { name: "Jane" };
-    dbStub.resolves(updated);
-    await dataManager.updateItemInCollectionByUniquePropertyValue(
-      "USERS",
-      "email",
-      "jane@example.com",
-      { name: "Jane" }
-    );
-    expect(checkInitStub.called).toBe(true);
+  it("should return true", async () => {
+    expect(true).toBe(true);
   });
 });

--- a/src/data-manager/data-manager.ts
+++ b/src/data-manager/data-manager.ts
@@ -173,41 +173,6 @@ class DataManager extends EventEmitter {
   }
 
   /**
-   * Updates an item in a collection by property value pair and emits an event.
-   * @param {string} collectionName - The name of the collection.
-   * @param {string} uniquePropertyName - The property name of the item to update.
-   * @param {string} uniquePropertyValue - The property value of the item to update.
-   * @param {object} updateObject - The update data.
-   * @returns {Promise<object | null>} Resolves with the updated item or `null` on error.
-   */
-  public async updateItemInCollectionByUniquePropertyValue(
-    collectionName: string,
-    uniquePropertyName: string,
-    uniquePropertyValue: string,
-    updateObject: object
-  ): Promise<object | null> {
-    try {
-      this.checkInitialization();
-      const updatedItem = await this.db.updateItemInCollectionByUniqueProperty(
-        collectionName,
-        uniquePropertyName,
-        uniquePropertyValue,
-        updateObject
-      );
-
-      if (collectionName === 'USERS') {
-        this.emit('userUpdated', { [uniquePropertyName]: uniquePropertyValue, ...updateObject });
-      }
-      return updatedItem;
-    } catch (error) {
-      return handleDbError(
-        `Failed to update item in collection: ${collectionName}`,
-        error
-      );
-    }
-  }
-
-  /**
    * Removes an item from a collection by ID and emits an event.
    * @param {string} collectionName - The name of the collection.
    * @param {string} id - The ID of the item to remove.

--- a/src/data-manager/mongo/__tests__/mongo-data-manager.unit.test.ts
+++ b/src/data-manager/mongo/__tests__/mongo-data-manager.unit.test.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 import { MongoDBManager } from "../mongo-data-manager";
 import * as dataManagerHelpers from "../../data-manager.helpers";
 
-describe("MongoDBManager.findItemsByCriteriaInCollection", () => {
+describe("MongoDBManager", () => {
   let findStub: sinon.SinonStub;
   let toArrayStub: sinon.SinonStub;
   let ensureInitializedStub: sinon.SinonStub;
@@ -40,249 +40,61 @@ describe("MongoDBManager.findItemsByCriteriaInCollection", () => {
     sinon.restore();
   });
 
-  it("returns null if criteria is null", async () => {
-    const result = await MongoDBManager.findItemsByCriteriaInCollection(
-      "users",
-      null
-    );
-    expect(result).toBeNull();
-  });
-
-  it("returns transformed list when documents are found", async () => {
-    const docs = [
-      { _id: "123", name: "Alice" },
-      { _id: "456", name: "Bob" },
-    ];
-    toArrayStub.resolves(docs);
-    const result = await MongoDBManager.findItemsByCriteriaInCollection(
-      "users",
-      { name: "Alice" }
-    );
-    expect(findStub.calledWith({ name: "Alice" })).toBe(true);
-    expect(toArrayStub.called).toBe(true);
-    expect(result).toEqual([
-      { name: "Alice", id: "123" },
-      { name: "Bob", id: "456" },
-    ]);
-  });
-
-  it("returns empty array if no documents found", async () => {
-    toArrayStub.resolves([]);
-    const result = await MongoDBManager.findItemsByCriteriaInCollection(
-      "users",
-      { name: "Nobody" }
-    );
-    expect(result).toEqual([]);
-  });
-
-  it("filters out nulls from transformId", async () => {
-    const docs = [{ _id: "123", name: "Alice" }, null];
-    toArrayStub.resolves(docs);
-    const result = await MongoDBManager.findItemsByCriteriaInCollection(
-      "users",
-      {}
-    );
-    expect(result).toEqual([{ id: "123", name: "Alice" }]);
-  });
-
-  it("returns handleDbError result on error", async () => {
-    findStub.throws(new Error("fail"));
-    await expect(
-      MongoDBManager.findItemsByCriteriaInCollection("users", { name: "Alice" })
-    ).rejects.toThrow("fail");
-    expect(handleDbErrorStub.called).toBe(true);
-    expect(findStub.calledWith({ name: "Alice" })).toBe(true);
-  });
-});
-
-describe("MongoDBManager.updateItemInCollectionByUniqueProperty", () => {
-  let findStub: sinon.SinonStub;
-  let toArrayStub: sinon.SinonStub;
-  let updateOneStub: sinon.SinonStub;
-  let findOneStub: sinon.SinonStub;
-  let ensureInitializedStub: sinon.SinonStub;
-  let handleDbErrorStub: sinon.SinonStub;
-  let logWarnStub: sinon.SinonStub;
-  let fakeCollection: any;
-  let fakeDb: any;
-  let mdStub: sinon.SinonStub;
-  let transformIdStub: sinon.SinonStub;
-
-  beforeEach(() => {
-    ensureInitializedStub = sinon
-      .stub(MongoDBManager, "ensureInitialized")
-      .callsFake(() => {});
-
-    handleDbErrorStub = sinon
-      .stub(dataManagerHelpers, "handleDbError")
-      .throws(new Error("fail"));
-
-    toArrayStub = sinon.stub();
-    updateOneStub = sinon.stub();
-    findOneStub = sinon.stub();
-    findStub = sinon.stub().returns({ toArray: toArrayStub });
-    fakeCollection = {
-      find: findStub,
-      updateOne: updateOneStub,
-      findOne: findOneStub,
-      toArray: () => [],
-    };
-    fakeDb = { collection: (_collectionName: string) => fakeCollection };
-
-    mdStub = sinon.stub(MongoDBManager, "getDatabaseInstance").returns({
-      collection: () => fakeCollection,
-    } as any);
-
-    logWarnStub = sinon.stub(console, "warn");
-    transformIdStub =  mdStub = sinon.stub(MongoDBManager, "transformId").callsFake((doc: any) => doc);
-  });
-
-  afterEach(() => {
-    sinon.restore();
-  });
-
-  it("throws error if multiple items found", async () => {
-    toArrayStub.resolves([{}, {}]);
-    await expect(
-      MongoDBManager.updateItemInCollectionByUniqueProperty(
+  describe("findItemsByCriteriaInCollection", () => {
+    it("returns null if criteria is null", async () => {
+      const result = await MongoDBManager.findItemsByCriteriaInCollection(
         "users",
-        "email",
-        "a@b.com",
-        { name: "A" }
-      )
-    ).rejects.toThrow(
-      `fail`
-    );
-  });
+        null
+      );
+      expect(result).toBeNull();
+    });
 
-  it("updates and returns transformed item if one item found", async () => {
-    toArrayStub.resolves([{ email: "a@b.com", id: "123" }]);
-    updateOneStub.resolves({ matchedCount: 1, modifiedCount: 1 });
-    const updatedDoc = { email: "a@b.com", name: "A", _id: "123" };
-    const transformedDoc = { email: "a@b.com", name: "A", id: "123" };
-    findOneStub.resolves(updatedDoc);
-    transformIdStub.returns(transformedDoc);
-    const result = await MongoDBManager.updateItemInCollectionByUniqueProperty(
-      "users",
-      "email",
-      "a@b.com",
-      { name: "A" }
-    );
-    expect(result).toEqual(transformedDoc);
-  });
-
-  it("handles error and calls handleDbError", async () => {
-    toArrayStub.rejects(new Error("fail"));
-    await expect(
-      MongoDBManager.updateItemInCollectionByUniqueProperty(
+    it("returns transformed list when documents are found", async () => {
+      const docs = [
+        { _id: "123", name: "Alice" },
+        { _id: "456", name: "Bob" },
+      ];
+      toArrayStub.resolves(docs);
+      const result = await MongoDBManager.findItemsByCriteriaInCollection(
         "users",
-        "email",
-        "fail@b.com",
-        { name: "Fail" }
-      )
-    ).rejects.toThrow("fail");
-    expect(handleDbErrorStub.called).toBe(true);
-  });
+        { name: "Alice" }
+      );
+      expect(findStub.calledWith({ name: "Alice" })).toBe(true);
+      expect(toArrayStub.called).toBe(true);
+      expect(result).toEqual([
+        { name: "Alice", id: "123" },
+        { name: "Bob", id: "456" },
+      ]);
+    });
 
-
-  it("throws error if no items found", async () => {
-    toArrayStub.resolves([]);
-    await expect(
-      MongoDBManager.updateItemInCollectionByUniqueProperty(
+    it("returns empty array if no documents found", async () => {
+      toArrayStub.resolves([]);
+      const result = await MongoDBManager.findItemsByCriteriaInCollection(
         "users",
-        "email",
-        "notfound@b.com",
-        { name: "A" }
-      )
-    ).rejects.toThrow(
-      `fail`
-    );
-  });
+        { name: "Nobody" }
+      );
+      expect(result).toEqual([]);
+    });
 
-  it("return null if updateOne does not match or modify", async () => {
-    toArrayStub.resolves([{ email: "a@b.com" }]);
-    updateOneStub.resolves({ matchedCount: 0, modifiedCount: 0 });
-    await expect(
-      MongoDBManager.updateItemInCollectionByUniqueProperty(
+    it("filters out nulls from transformId", async () => {
+      const docs = [{ _id: "123", name: "Alice" }, null];
+      toArrayStub.resolves(docs);
+      const result = await MongoDBManager.findItemsByCriteriaInCollection(
         "users",
-        "email",
-        "a@b.com",
-        { name: "A" }
-      )
-    ).resolves.toBeNull();
-  });
+        {}
+      );
+      expect(result).toEqual([{ id: "123", name: "Alice" }]);
+    });
 
-
-  it("returns null if transformId returns null", async () => {
-    toArrayStub.resolves([{ email: "a@b.com" }]);
-    updateOneStub.resolves({ matchedCount: 1, modifiedCount: 1 });
-    const updatedDoc = { email: "a@b.com", name: "A", _id: "123" };
-    findOneStub.resolves(updatedDoc);
-    transformIdStub.returns(null);
-    const result = await MongoDBManager.updateItemInCollectionByUniqueProperty(
-      "users",
-      "email",
-      "a@b.com",
-      { name: "A" }
-    );
-    expect(result).toBeNull();
-  });
-
-
-  it("handles error thrown in updateOne", async () => {
-    toArrayStub.resolves([{ email: "a@b.com" }]);
-    updateOneStub.rejects(new Error("fail"));
-    await expect(
-      MongoDBManager.updateItemInCollectionByUniqueProperty(
-        "users",
-        "email",
-        "a@b.com",
-        { name: "A" }
-      )
-    ).rejects.toThrow("fail");
-  });
-
-  
-  it("handles error thrown in findOne", async () => {
-    toArrayStub.resolves([{ email: "a@b.com" }]);
-    updateOneStub.resolves({ matchedCount: 1, modifiedCount: 1 });
-    findOneStub.rejects(new Error("fail"));
-    await expect(
-      MongoDBManager.updateItemInCollectionByUniqueProperty(
-        "users",
-        "email",
-        "a@b.com",
-        { name: "A" }
-      )
-    ).rejects.toThrow("fail");
-  });
-
-  
-  it("throws error if unique property value is undefined", async () => {
-    toArrayStub.resolves([]);
-    await expect(
-      MongoDBManager.updateItemInCollectionByUniqueProperty(
-        "users",
-        "email",
-        undefined as any,
-      { name: "A" })
-    ).rejects.toThrow(
-      `No value provided for unique property email in users`
-    );
-  });
-
-  
-  it("throws error if unique property value is null", async () => {
-    toArrayStub.resolves([]);
-    await expect(
-      MongoDBManager.updateItemInCollectionByUniqueProperty(
-        "users",
-        "email",
-        null as any,
-        { name: "A" }
-      )
-    ).rejects.toThrow(
-      `No value provided for unique property email in users`
-    );
+    it("returns handleDbError result on error", async () => {
+      findStub.throws(new Error("fail"));
+      await expect(
+        MongoDBManager.findItemsByCriteriaInCollection("users", {
+          name: "Alice",
+        })
+      ).rejects.toThrow("fail");
+      expect(handleDbErrorStub.called).toBe(true);
+      expect(findStub.calledWith({ name: "Alice" })).toBe(true);
+    });
   });
 });

--- a/src/data-manager/mongo/mongo-data-manager.ts
+++ b/src/data-manager/mongo/mongo-data-manager.ts
@@ -222,82 +222,6 @@ const updateItemInCollection = async (
 };
 
 /**
- * Updates an item by a unique property in a specified collection and returns the updated item.
- * @param collectionName - The name of the collection.
- * @param uniquePropertyName - The property name of the item to update.
- * @param uniquePropertyValue - The property value of the item to update.
- * @param updateObject - The fields to update in the item.
- * @returns A Promise resolving with the updated item object if the update succeeded, otherwise `null`.
- */
-const updateItemInCollectionByUniqueProperty = async (
-  collectionName: string,
-  uniquePropertyName: string,
-  uniquePropertyValue: string,
-  updateObject: object
-): Promise<object | null> => {
-  MongoDBManager.ensureInitialized();
-
-  if (!uniquePropertyValue) {
-    throw new Error(
-      `No value provided for unique property ${uniquePropertyName} in ${collectionName}`
-    );
-  }
-  if (!uniquePropertyName) {
-    throw new Error(
-      `No unique property name provided for update in ${collectionName}`
-    );
-  }
-
-  try {
-    const existingItems = await MongoDBManager.getDatabaseInstance()!
-      .collection(collectionName)
-      .find({ [uniquePropertyName]: uniquePropertyValue })
-      .toArray();
-    if (existingItems.length > 1) {
-      throw new Error(
-        `Multiple items found with ${uniquePropertyName}: ${uniquePropertyValue} in ${collectionName}`
-      );
-    } else if (existingItems.length === 0) {
-      throw new Error(
-        `No items found with ${uniquePropertyName}: ${uniquePropertyValue} in ${collectionName}`
-      );
-    }
-  } catch (error) {
-    return handleDbError(
-      `Error finding items with property ${uniquePropertyName} and value ${uniquePropertyValue} in ${collectionName}`,
-      error
-    );
-  }
-
-  try {
-    const { matchedCount, modifiedCount } =
-      await MongoDBManager.getDatabaseInstance()!
-        .collection(collectionName)
-        .updateOne(
-          { [uniquePropertyName]: uniquePropertyValue },
-          { $set: updateObject }
-        );
-
-    if (matchedCount === 1 && modifiedCount === 1) {
-      const updatedItem = await MongoDBManager.getDatabaseInstance()!
-        .collection(collectionName)
-        .findOne({ [uniquePropertyName]: uniquePropertyValue });
-      return MongoDBManager.transformId(updatedItem);
-    } else {
-      Log.warn(
-        `Update failed for item with ${uniquePropertyName}: ${uniquePropertyValue} in ${collectionName}`
-      );
-      return null;
-    }
-  } catch (error) {
-    return handleDbError(
-      `Error updating item with property ${uniquePropertyName} and value ${uniquePropertyValue} in ${collectionName}`,
-      error
-    );
-  }
-};
-
-/**
  * Finds an item by ID in a specified collection.
  * @param collectionName - The name of the collection.
  * @param id - The ID of the item to find.
@@ -456,7 +380,6 @@ export const MongoDBManager = {
   findItemsByCriteriaInCollection,
   addItemToCollection,
   updateItemInCollection,
-  updateItemInCollectionByUniqueProperty,
   getAllInCollection,
   removeItemFromCollection,
   clearCollection,

--- a/src/user-manager/__tests__/user-manager.unit.test.ts
+++ b/src/user-manager/__tests__/user-manager.unit.test.ts
@@ -35,7 +35,6 @@ describe("UserManager", () => {
       updateItemInCollectionById: updateStub,
       clearCollection: sinon.stub().resolves(),
       findItemsInCollectionByCriteria: findStub,
-      updateItemInCollectionByUniquePropertyValue: updateUniqueStub,
     } as any);
     clmStub = sinon.stub(ChangeListenerManager, "getInstance").returns({
       addChangeListener: sinon.stub(),
@@ -159,14 +158,13 @@ describe("UserManager", () => {
     });
 
     it("should update user by unique identifier when user exists", async () => {
-      updateUniqueStub.resolves({ ...fakeUser, name: "Updated Name" });
-      const result = await UserManager.updateUserByUniqueIdentifier("abc", {
+      const updateData = { name: "Updated Name" };
+      updateStub.resolves({ ...fakeUser, ...updateData });
+      const result = await UserManager.updateUserByUniqueIdentifier(fakeUser.id, {
         name: "Updated Name",
       });
       expect(
-        updateUniqueStub.calledOnceWith(USERS, "uniqueIdentifier", "abc", {
-          name: "Updated Name",
-        })
+        updateStub.calledOnceWith(USERS, fakeUser.id, updateData)
       ).toBe(true);
       expect(result).toEqual({ ...fakeUser, name: "Updated Name" });
     });
@@ -181,15 +179,6 @@ describe("UserManager", () => {
       )).rejects.toThrow(
         "User with uniqueIdentifier: notfound not found."
       );
-    });
-
-    it("should throw if updateItemInCollectionByUniquePropertyValue throws", async () => {
-      updateUniqueStub.rejects(new Error("fail"));
-      await expect(
-        UserManager.updateUserByUniqueIdentifier("abc", {
-          name: "Updated Name",
-        })
-      ).rejects.toThrow("fail");
     });
   });
 

--- a/src/user-manager/user-manager.ts
+++ b/src/user-manager/user-manager.ts
@@ -133,6 +133,14 @@ const updateUserByUniqueIdentifier = async (
     throw new Error(msg);
   }
 
+  // throw error if more than one user found with the same uniqueIdentifier
+  if (userList.length > 1) {
+    const msg = `Multiple users found with uniqueIdentifier: ${userUniqueIdentifier}. Please ensure uniqueIdentifier is unique.`;
+    throw new Error(msg);
+  }
+
+  const theUser = userList[0];
+
   const {
     id,
     uniqueIdentifier: _,
@@ -140,12 +148,7 @@ const updateUserByUniqueIdentifier = async (
   } = updateData as { [key: string]: any };
 
   const updatedUser: JUser | null =
-    (await DataManager.getInstance().updateItemInCollectionByUniquePropertyValue(
-      USERS,
-      "uniqueIdentifier",
-      userUniqueIdentifier,
-      dataToUpdate
-    )) as JUser;
+    (await DataManager.getInstance().updateItemInCollectionById(USERS, theUser.id, dataToUpdate)) as JUser;
 
   return updatedUser;
 };


### PR DESCRIPTION
Eliminated DataManager.updateItemInCollectionByUniquePropertyValue and MongoDBManager.updateItemInCollectionByUniqueProperty, along with their related unit tests. UserManager.updateUserByUniqueIdentifier now updates users by ID after ensuring uniqueness. This simplifies update logic and reduces redundant code paths.