### PR TITLE
Refactor test stubs and clarify test descriptions

### DIFF
--- a/src/data-manager/__tests__/data-manager.unit.test.ts
+++ b/src/data-manager/__tests__/data-manager.unit.test.ts
@@ -20,7 +20,7 @@ describe("DataManager", () => {
 
     mongoFindStub = sandbox.stub(MongoDBManager, "findItemsInCollection");
 
-    jest.spyOn(console, "error").mockImplementation(() => {});
+    sandbox.stub(console, "error").callsFake(() => {});
     handleDbErrorStub = sandbox
       .stub(dataManagerHelpers, "handleDbError")
       .throws(new Error("fail"));
@@ -31,7 +31,7 @@ describe("DataManager", () => {
   });
 
   describe("findItemsInCollection", () => {
-    it("returns null if collection name is falsy", async () => {
+    it("returns null if collection name is an empty string", async () => {
       const result = await DataManager.getInstance().findItemsInCollection("", {
         foo: "bar",
       });

--- a/src/data-manager/mongo/__tests__/mongo-data-manager.unit.test.ts
+++ b/src/data-manager/mongo/__tests__/mongo-data-manager.unit.test.ts
@@ -16,7 +16,7 @@ describe("MongoDBManager", () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    jest.spyOn(console, "error").mockImplementation(() => {});
+    sandbox.stub(console, "error").callsFake(() => {});
     ensureInitializedStub = sandbox
       .stub(MongoDBManager, "ensureInitialized")
       .callsFake(() => {
@@ -101,7 +101,7 @@ describe("MongoDBManager", () => {
   });
 
   describe("findItemsInCollection", () => {
-    it("returns null if collection name is falsy", async () => {
+    it("returns null if collection name is an empty string", async () => {
       const result = await MongoDBManager.findItemsInCollection("", {
         foo: "bar",
       });


### PR DESCRIPTION
Replaced jest.spyOn with sinon sandbox stubs for console.error in unit tests for consistency. Updated test descriptions to specify 'empty string' instead of 'falsy' for collection name checks.