### PR TITLE
set publishedTimestamp in publishEvent.

### DIFF
--- a/src/event/event-queue.ts
+++ b/src/event/event-queue.ts
@@ -41,6 +41,7 @@ export const publishEvent = async (
     const eventInstance: JEvent = {
       eventType,
       generatedTimestamp,
+      publishedTimestamp: new Date(),
       eventDetails,
     };
 


### PR DESCRIPTION
I forgot to set the publishedTimestamp field in events when they are published. So I added that in. One line of code.