### PR TITLE
Fix formatting in _read function definition

### DIFF
--- a/src/data-manager/mongo/mongo-data-manager.ts
+++ b/src/data-manager/mongo/mongo-data-manager.ts
@@ -133,7 +133,7 @@ const getCollectionChangeReadable = (
     .watch(filterList, options);
 
   const collectionChangeReadable = new Readable({ objectMode: true });
-  collectionChangeReadable._read = () => { };
+  collectionChangeReadable._read = () => {};
 
   const handleStreamClose = () => {
     Log.info(`Change stream for ${collectionName} closed`);


### PR DESCRIPTION
Removed unnecessary space in the _read function assignment for better code consistency.

### Description

-


### Related Jira Tickets

-


### Comments 

-


Please ensure all items are complete before requesting a review:

- [ ] **Code Completed**: All code for the feature or bugfix has been implemented.
- [ ] **Unit Tests Added**: Unit tests are written for all new functionality, covering edge cases where applicable.
- [ ] **Integration Tests (where necessary)**: Integration tests are added for interactions between modules or components.
- [ ] **All Tests Passing**: All unit and integration tests are passing.
- [ ] **Type Safety Checked**: Ensure TypeScript types are correctly defined and used. Avoid `any` types without proper justification.
- [ ] **Typedoc Comments Added**: Ensure all functions, classes, interfaces, and types are documented using TypeDoc syntax.
- [ ] **Code Formatting**: All code files are formatted according to the project’s standards (e.g., Prettier, ESLint) and no linting errors remain.
- [ ] **No Console Logs**: Remove any `console.log` or other debugging output from the code.
- [ ] **Documentation Updated**: Update relevant project documentation (e.g., README, configuration guides) if necessary.

---